### PR TITLE
Update build JDK version to 22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,3 +116,12 @@ jar {
         attributes "Main-Class": "me.hannsi.test.TestGuiFrame"
     }
 }
+
+sourceCompatibility = JavaVersion.VERSION_22
+targetCompatibility = JavaVersion.VERSION_22
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(22)
+    }
+}


### PR DESCRIPTION
Update `build.gradle` to specify JDK version 22 for building the project.

* Add `sourceCompatibility` and `targetCompatibility` properties to specify JDK version 22.
* Add `java` block to specify JDK version 22 using the toolchain.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hannsi-to/LFJG-LiteFrameJavaGui/pull/4?shareId=bd332da5-c669-466b-8106-525ea8daab14).